### PR TITLE
Add tracing headers for the delay and status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ If you are specifying a delayed response - you can customise the behaviour of th
 
 ```properties
 chaos.strategy.delayResponse.fixedPeriod=true       # if number of seconds to delay is constant or random (default is false)
-
+chaos.tracing.headers=false                         # If this is set to true then 2 headers will be added to the request, 
+                                                     'x-clusterfk-delayed-by' and 'x-clusterfk-status-code'.
 chaos.strategy.delayResponse.seconds=60             # if fixed-period delay - number of seconds to delay each requests
 chaos.strategy.delayResponse.random.maxSeconds=120  # if delay is random - maximum amount of time a request can last
 ```

--- a/src/main/java/dev/andymacdonald/config/ChaosProxyConfigurationService.java
+++ b/src/main/java/dev/andymacdonald/config/ChaosProxyConfigurationService.java
@@ -34,6 +34,9 @@ public class ChaosProxyConfigurationService
     @Value("${chaos.strategy.delayResponse.fixedPeriod:false}")
     private boolean fixedDelayPeriod;
 
+    @Value("${chaos.tracing.headers:true}")
+    private boolean tracingHeaders;
+
     public ChaosStrategy getInitialChaosStrategy()
     {
         try

--- a/src/main/java/dev/andymacdonald/controller/ChaosController.java
+++ b/src/main/java/dev/andymacdonald/controller/ChaosController.java
@@ -1,6 +1,7 @@
 package dev.andymacdonald.controller;
 
 
+import com.sun.net.httpserver.Headers;
 import dev.andymacdonald.chaos.ChaosService;
 import dev.andymacdonald.io.MultipartInputStreamFileResource;
 import dev.andymacdonald.url.build.ProxyTargetUrlBuilder;
@@ -42,7 +43,9 @@ public class ChaosController
     private ChaosService chaosService;
     private Logger log = LoggerFactory.getLogger(ChaosController.class);
 
-    public ChaosController(RestTemplateBuilder restTemplateBuilder, ProxyTargetUrlBuilder targetUrlBuilder, ChaosService chaosService)
+    public ChaosController(RestTemplateBuilder restTemplateBuilder,
+                           ProxyTargetUrlBuilder targetUrlBuilder,
+                           ChaosService chaosService)
     {
         this.restTemplateBuilder = restTemplateBuilder;
         this.targetUrlBuilder = targetUrlBuilder;
@@ -127,6 +130,14 @@ public class ChaosController
             int responseStatusCode = chaosService.getChaosStatusCode();
             byte[] responseBody = chaosService.getChaosResponseEntity().getBody();
             HttpHeaders responseHeaders = chaosService.getChaosResponseEntity().getHeaders();
+
+            if (chaosService.isTracingHeaders())
+            {
+                chaosService.getChaosResponseEntity().getHeaders();
+                servletResponse.addHeader("x-clusterfk-status-code", Integer.toString(chaosService.getChaosStatusCode()));
+                servletResponse.addHeader("x-clusterfk-delayed-by", Long.toString(chaosService.getDelayedBy()));
+
+            }
 
             log.info("{} responded with status code {}", targetUrl, responseStatusCode);
 

--- a/src/test/java/dev/andymacdonald/chaos/ChaosServiceTest.java
+++ b/src/test/java/dev/andymacdonald/chaos/ChaosServiceTest.java
@@ -59,7 +59,7 @@ public class ChaosServiceTest
         DelayService mockDelayService = mock(DelayService.class);
         Logger mockLogger = mock(Logger.class);
         Supplier<ResponseEntity<byte[]>> mockResponseEntity = () -> mock(ResponseEntity.class);
-        ChaosProxyConfigurationService chaosProxyConfigurationService = new ChaosProxyConfigurationService(mockLogger, "", "", 30, 60, true);
+        ChaosProxyConfigurationService chaosProxyConfigurationService = new ChaosProxyConfigurationService(mockLogger, "", "", 30, 60, true, false);
         ChaosService chaosService = new ChaosService(chaosProxyConfigurationService, mockDelayService);
         chaosService.setActiveChaosStrategy(ChaosStrategy.DELAY_RESPONSE);
         chaosService.processRequestAndApplyChaos(mockResponseEntity);
@@ -74,7 +74,7 @@ public class ChaosServiceTest
         ResponseEntity<byte[]> mockResponseEntity = mock(ResponseEntity.class);
         Supplier<ResponseEntity<byte[]>> mockResponseEntitySupplier = mock(Supplier.class);
         when(mockResponseEntitySupplier.get()).thenReturn(mockResponseEntity);
-        ChaosProxyConfigurationService chaosProxyConfigurationService = new ChaosProxyConfigurationService(mockLogger, "", "", 30, 60, true);
+        ChaosProxyConfigurationService chaosProxyConfigurationService = new ChaosProxyConfigurationService(mockLogger, "", "", 30, 60, true, false);
         ChaosService chaosService = new ChaosService(chaosProxyConfigurationService, mockDelayService);
         chaosService.setActiveChaosStrategy(ChaosStrategy.DELAY_RESPONSE);
         chaosService.processRequestAndApplyChaos(mockResponseEntitySupplier);
@@ -88,7 +88,7 @@ public class ChaosServiceTest
         DelayService mockDelayService = mock(DelayService.class);
         Logger mockLogger = mock(Logger.class);
         Supplier<ResponseEntity<byte[]>> mockResponseEntitySupplier = mock(Supplier.class);
-        ChaosProxyConfigurationService chaosProxyConfigurationService = new ChaosProxyConfigurationService(mockLogger, "", "", 30, 60, true);
+        ChaosProxyConfigurationService chaosProxyConfigurationService = new ChaosProxyConfigurationService(mockLogger, "", "", 30, 60, true, false);
         ChaosService chaosService = new ChaosService(chaosProxyConfigurationService, mockDelayService);
         chaosService.setActiveChaosStrategy(ChaosStrategy.INTERNAL_SERVER_ERROR);
         chaosService.processRequestAndApplyChaos(mockResponseEntitySupplier);
@@ -101,7 +101,7 @@ public class ChaosServiceTest
         DelayService mockDelayService = mock(DelayService.class);
         Logger mockLogger = mock(Logger.class);
         Supplier<ResponseEntity<byte[]>> mockResponseEntitySupplier = mock(Supplier.class);
-        ChaosProxyConfigurationService chaosProxyConfigurationService = new ChaosProxyConfigurationService(mockLogger, "", "", 30, 60, true);
+        ChaosProxyConfigurationService chaosProxyConfigurationService = new ChaosProxyConfigurationService(mockLogger, "", "", 30, 60, true, false);
         ChaosService chaosService = new ChaosService(chaosProxyConfigurationService, mockDelayService);
         chaosService.setActiveChaosStrategy(ChaosStrategy.BAD_REQUEST);
         chaosService.processRequestAndApplyChaos(mockResponseEntitySupplier);

--- a/src/test/java/dev/andymacdonald/config/ChaosProxyConfigurationServiceTest.java
+++ b/src/test/java/dev/andymacdonald/config/ChaosProxyConfigurationServiceTest.java
@@ -33,7 +33,7 @@ public class ChaosProxyConfigurationServiceTest
     @Test
     public void proxyConfigService_withInvalidChaosStrategy_returnsNullAndLogsWarning()
     {
-        ChaosProxyConfigurationService chaosProxyConfigurationService = new ChaosProxyConfigurationService(mockLogger, "", "egg", 0, 120, false);
+        ChaosProxyConfigurationService chaosProxyConfigurationService = new ChaosProxyConfigurationService(mockLogger, "", "egg", 0, 120, false, false);
         assertNull(chaosProxyConfigurationService.getInitialChaosStrategy());
         verify(mockLogger).warn(anyString());
     }
@@ -41,7 +41,7 @@ public class ChaosProxyConfigurationServiceTest
     @Test
     public void proxyConfigService_withNullChaosStrategy_returnsNullAndLogsWarning()
     {
-        ChaosProxyConfigurationService chaosProxyConfigurationService = new ChaosProxyConfigurationService(mockLogger, "", null, 0, 120, false);
+        ChaosProxyConfigurationService chaosProxyConfigurationService = new ChaosProxyConfigurationService(mockLogger, "", null, 0, 120, false, false);
         assertNull(chaosProxyConfigurationService.getInitialChaosStrategy());
         verify(mockLogger).warn(anyString());
     }
@@ -50,26 +50,24 @@ public class ChaosProxyConfigurationServiceTest
     public void proxyConfigService_withValidChaosStrategy_returnsNamedChaosStrategy()
     {
         assertEquals(new ChaosProxyConfigurationService(
-                mockLogger, "", "NO_CHAOS", 0, 120, false)
+                mockLogger, "", "NO_CHAOS", 0, 120, false, false)
                 .getInitialChaosStrategy(), ChaosStrategy.NO_CHAOS);
 
         assertEquals(new ChaosProxyConfigurationService(
-                mockLogger, "", "INTERNAL_SERVER_ERROR", 0, 120, false)
+                mockLogger, "", "INTERNAL_SERVER_ERROR", 0, 120, false, false)
                 .getInitialChaosStrategy(), ChaosStrategy.INTERNAL_SERVER_ERROR);
 
         assertEquals(new ChaosProxyConfigurationService(
-                mockLogger, "", "BAD_REQUEST", 0, 120, false)
+                mockLogger, "", "BAD_REQUEST", 0, 120, false, false)
                 .getInitialChaosStrategy(), ChaosStrategy.BAD_REQUEST);
 
         assertEquals(new ChaosProxyConfigurationService(
-                mockLogger, "", "DELAY_RESPONSE", 0, 120, false)
+                mockLogger, "", "DELAY_RESPONSE", 0, 120, false, false)
                 .getInitialChaosStrategy(), ChaosStrategy.DELAY_RESPONSE);
 
         assertEquals(new ChaosProxyConfigurationService(
-                mockLogger, "", "RANDOM_HAVOC", 0, 120, false)
+                mockLogger, "", "RANDOM_HAVOC", 0, 120, false, false)
                 .getInitialChaosStrategy(), ChaosStrategy.RANDOM_HAVOC);
 
     }
-
-
 }

--- a/src/test/java/dev/andymacdonald/controller/ChaosControllerTest.java
+++ b/src/test/java/dev/andymacdonald/controller/ChaosControllerTest.java
@@ -148,4 +148,15 @@ public class ChaosControllerTest
         this.mockMvc.perform(delete("/")).andDo(print()).andExpect(status().is5xxServerError())
                 .andExpect(content().string(containsString("Error")));
     }
-}
+    @Test
+
+    public void chaosController_withTracingEnabledAddsCorrectHeaders() throws Exception
+    {
+        stubFor(com.github.tomakehurst.wiremock.client.WireMock.delete(urlMatching("/"))
+                .willReturn(aResponse()
+                        .withStatus(500)
+                        .withHeader("Content-Type", "text/xml")
+                        .withBody("<response>Error</response>")));
+        this.mockMvc.perform(delete("/")).andDo(print()).andExpect(status().is5xxServerError())
+                .andExpect(content().string(containsString("Error")));
+    }}


### PR DESCRIPTION
closes #1 

Adds tracing headers if configured. 

Off by default