### PR TITLE
Bug/3 encoding curly brackets

### DIFF
--- a/src/main/java/dev/andymacdonald/controller/ChaosController.java
+++ b/src/main/java/dev/andymacdonald/controller/ChaosController.java
@@ -83,7 +83,7 @@ public class ChaosController
 
     private URI buildUri(HttpServletRequest servletRequest, URL targetUrl)
     {
-        return UriComponentsBuilder.fromUriString(targetUrl.toString()).query(servletRequest.getQueryString()).build(true).toUri();
+        return UriComponentsBuilder.fromUriString(targetUrl.toString()).query(servletRequest.getQueryString()).build().toUri();
     }
 
     private HttpHeaders copyHeaders(HttpServletRequest servletRequest)

--- a/src/test/java/dev/andymacdonald/controller/ChaosControllerTest.java
+++ b/src/test/java/dev/andymacdonald/controller/ChaosControllerTest.java
@@ -78,7 +78,19 @@ public class ChaosControllerTest
     }
 
     @Test
-    public void chaosController_withPOSTrequest_proxiesToMockRealServiceAndReturns200ResponseIfSuccessful() throws Exception
+    public void chaosController_withGETrequest_withEncodedCurlyBrackets_proxiesToMockRealServiceAndReturns4xx() throws Exception
+    {
+        stubFor(com.github.tomakehurst.wiremock.client.WireMock.get(urlMatching("/%7B%7D"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/xml")
+                        .withBody("<response>Content</response>")));
+        when(mockTargetBuilder.buildUrl(any())).thenReturn(new URL(new URL("http://google.com"), "/{}"));
+        this.mockMvc.perform(get("/%7B%7D")).andDo(print()).andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    public void chaosController_withPOSTrequest_proxiesToMockRealServiceAndReturns404ResponseIfSuccessful() throws Exception
     {
         stubFor(com.github.tomakehurst.wiremock.client.WireMock.post(urlMatching("/"))
                 .willReturn(aResponse()


### PR DESCRIPTION
Thought I'd have a look at this issue (#3 ) 

The fix in this pull request means that calls with encoded curly brackets now returns a 404 not found error and doesn't crash the system with a 500 error. 

Haven't incremented the version number in the POM as it looks like it's staying at '0.0.1-SNAPSHOT', but happy to change if required. 