### PR TITLE
Make ChaosService more thread-safe

### DIFF
--- a/src/main/java/dev/andymacdonald/chaos/ChaosResult.java
+++ b/src/main/java/dev/andymacdonald/chaos/ChaosResult.java
@@ -1,0 +1,16 @@
+package dev.andymacdonald.chaos;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@Builder
+public class ChaosResult
+{
+    private final int chaosStatusCode;
+
+    private final ResponseEntity<byte[]> chaosResponseEntity;
+
+    private final Long delayedBy;
+}


### PR DESCRIPTION
A single `ChaosService` instance has been shared among multiple threads but it's internal state was used to exchange data with the `ChaosController`. It caused some responses to contain incorrect data.

In this change, an additional structure `ChaosResult` is used to return values to the service.