### PR TITLE
[#3] Fix requests with encoded URLs

### DIFF
--- a/src/main/java/dev/andymacdonald/url/build/ProxyTargetUrlBuilder.java
+++ b/src/main/java/dev/andymacdonald/url/build/ProxyTargetUrlBuilder.java
@@ -2,6 +2,8 @@ package dev.andymacdonald.url.build;
 
 import dev.andymacdonald.config.ChaosProxyConfigurationService;
 import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import java.net.MalformedURLException;
@@ -21,6 +23,14 @@ public class ProxyTargetUrlBuilder
 
     public URL buildUrl(HttpServletRequest request) throws MalformedURLException
     {
-        return new URL(chaosProxyConfigurationService.getDestinationServiceHostProtocolAndPort() + Optional.ofNullable(request.getServletPath()).orElse(""));
+        return new URL(chaosProxyConfigurationService.getDestinationServiceHostProtocolAndPort() + getRequestPath(request));
+    }
+
+    private String getRequestPath(HttpServletRequest request)
+    {
+        String contextPath = request.getContextPath();
+        String uri = request.getRequestURI();
+        Assert.isTrue(uri.startsWith(contextPath), "Expected request URI: " + uri + " to begin with context path: " + contextPath);
+        return uri.substring(contextPath.length());
     }
 }

--- a/src/test/java/dev/andymacdonald/url/build/ProxyTargetUrlBuilderTest.java
+++ b/src/test/java/dev/andymacdonald/url/build/ProxyTargetUrlBuilderTest.java
@@ -21,6 +21,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 public class ProxyTargetUrlBuilderTest
 {
 
+    private final String contextPath;
     private final String path;
     private final URL expectedURL;
 
@@ -38,16 +39,20 @@ public class ProxyTargetUrlBuilderTest
     public static List<Object[]> balanceRates() throws MalformedURLException
     {
         return Arrays.asList(new Object[][] {
-                {"/images", new URL("https://www.google.com/images")},
-                {"/images/fish", new URL("https://www.google.com/images/fish")},
-                {"/images/fish/egg", new URL("https://www.google.com/images/fish/egg")},
-                {"/images/fish/egg/leg", new URL("https://www.google.com/images/fish/egg/leg")},
-                {"/", new URL("https://www.google.com/")},
-                {"", new URL("https://www.google.com")},
+                {"", "/images", new URL("https://www.google.com/images")},
+                {"", "/images/fish", new URL("https://www.google.com/images/fish")},
+                {"", "/images/fish/egg", new URL("https://www.google.com/images/fish/egg")},
+                {"", "/images/fish/egg/leg", new URL("https://www.google.com/images/fish/egg/leg")},
+                {"", "/", new URL("https://www.google.com/")},
+                {"", "", new URL("https://www.google.com")},
+
+                {"/foo", "/foo/images/fish/egg/leg", new URL("https://www.google.com/images/fish/egg/leg")},
+                {"/bar", "/bar", new URL("https://www.google.com")},
         });
     }
 
-    public ProxyTargetUrlBuilderTest(String path, URL expectedURL) {
+    public ProxyTargetUrlBuilderTest(String contextPath, String path, URL expectedURL) {
+        this.contextPath = contextPath;
         this.path = path;
         this.expectedURL = expectedURL;
     }
@@ -56,7 +61,8 @@ public class ProxyTargetUrlBuilderTest
     public void buildUrl_withRequestAndPath_returnsBuiltUrl() throws MalformedURLException
     {
         when(mockChaosProxyConfigurationService.getDestinationServiceHostProtocolAndPort()).thenReturn("https://www.google.com");
-        when(mockServletRequest.getServletPath()).thenReturn(this.path);
+        when(mockServletRequest.getContextPath()).thenReturn(this.contextPath);
+        when(mockServletRequest.getRequestURI()).thenReturn(this.path);
         URL actual = targetUrlBuilder.buildUrl(mockServletRequest);
         assertEquals(this.expectedURL, actual);
     }


### PR DESCRIPTION
It looks like `servlet.getServletPath()` returns a decoded path, even though the request contains an encoded one. Then, the request is rewritten by `ProxyTargetUrlBuilder` to create the request path for destination server. We could use `UriComponentsBuilder` to encode the path back but it just seems safer to use `getRequestURI()` which returns the original requested encoded URI that can be redirected into the destination server. And this solution has been proposed in this PR. 

Additionally, a few tests have been refactored to use the real `ProxyTargetUrlBuilder` logic instead of mocking it.

More literature about the URI encoding in Spring:
https://stackoverflow.com/questions/966077/java-reading-undecoded-url-from-servlet
https://stackoverflow.com/questions/4931323/whats-the-difference-between-getrequesturi-and-getpathinfo-methods-in-httpservl
